### PR TITLE
added renovate automerge for dockerfile and pip requirements

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,10 @@
   "extends": [
     "config:base"
   ],
+  "schedule": "every weekday",
+	"timezone": "Europe/Berlin",
+	"ignoreUnstable": true,
+	"stabilityDays": 7,
   "gitlabci": {
     "fileMatch": [
       "^.gitlab-ci.yml$"
@@ -10,12 +14,19 @@
   },
   "packageRules": [
     {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchManagers": ["dockerfile", "pip_requirements"],
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
       "matchDatasources": [
         "docker"
       ],
       "labels": [
         "Renovate::Docker"
       ]
+
     },
     {
       "matchManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,6 @@
       "labels": [
         "Renovate::Docker"
       ]
-
     },
     {
       "matchManagers": [


### PR DESCRIPTION
I've added the automerge function from renovate for changes in our dockerfile and pip_requirements . Those should be auto merged "silently" without creating a new PR for every change.