### PR TITLE
reverted changes to version 1.7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # use the official kics image as basis image
-FROM checkmarx/kics:v1.7.2-debian
+FROM checkmarx/kics:v1.7.1-debian
 
 WORKDIR /
 


### PR DESCRIPTION
There is currently an open issue for kics v1.7.2: https://github.com/Checkmarx/kics/issues/6481